### PR TITLE
Update handleMultipleOrder to take in : instead of space

### DIFF
--- a/src/main/java/order/Order.java
+++ b/src/main/java/order/Order.java
@@ -211,8 +211,8 @@ public class Order implements OrderInterface {
             }
 
             orderString = orderString.trim();
-            int itemIndex = Integer.parseInt(orderString.split(" ")[0]);
-            int quantity = Integer.parseInt(orderString.split(" ")[1]);
+            int itemIndex = Integer.parseInt(orderString.split(":")[0]);
+            int quantity = Integer.parseInt(orderString.split(":")[1]);
 
             OrderEntry orderEntry = new OrderEntry(listOfItems.getItems().get(itemIndex), quantity);
             this.orderEntries.add(orderEntry);

--- a/src/test/java/seedu/moneygowhere/OrderTest.java
+++ b/src/test/java/seedu/moneygowhere/OrderTest.java
@@ -41,7 +41,7 @@ class OrderTest {
     public void orderTest2() {
 
         MoneyGoWhere moneyGoWhere = new MoneyGoWhere();
-        runTest("addorder -I [1 69, 2 169]", moneyGoWhere);
+        runTest("addorder -I [1:69, 2:169]", moneyGoWhere);
 
         assertEquals("chicken rice", moneyGoWhere.transactions.getOrderList()
                 .get(moneyGoWhere.transactions.getOrderList().size() - 1)
@@ -105,7 +105,7 @@ class OrderTest {
     public void orderTest4() {
 
         MoneyGoWhere moneyGoWhere = new MoneyGoWhere();
-        runTest("addorder --items [0 69, 1 169]", moneyGoWhere);
+        runTest("addorder --items [0:69, 1:169]", moneyGoWhere);
 
         assertEquals("chicken rice", moneyGoWhere.transactions.getOrderList()
                 .get(moneyGoWhere.transactions.getOrderList().size() - 1)


### PR DESCRIPTION
When entering multiple items in an order the command to enter has been changed from

`addorder -I [0 10, 1 69]`

to 

`addorder -I [0:10,1:69]`